### PR TITLE
Fixes "get" command deprecation error

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -75,7 +75,7 @@ pyenv global 3.9.7
 pip install --upgrade pip
 
 # Install chamber of secrets
-go get github.com/segmentio/chamber
+go instal github.com/segmentio/chamber@latest
 
 # Setup aws-vault
 aws-vault add <name>


### PR DESCRIPTION
Running the script gave me the following error:

```
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

Changing that line to `go install github.com/segmentio/chamber@latest` seemed to fix it for me